### PR TITLE
Change Claude model from claude-3-5-sonnet-20241022 to claude-opus-4-1-20250805

### DIFF
--- a/llm/anthropic_client.py
+++ b/llm/anthropic_client.py
@@ -56,7 +56,7 @@ class ClaudeClient(LLMClient):
                 
                 # Log the request parameters for debugging
                 logging.info(f"Making Anthropic API request with:")
-                logging.info(f"  Model: claude-3-5-sonnet-20241022")
+                logging.info(f"  Model: claude-opus-4-1-20250805")
                 logging.info(f"  System prompt length: {len(system_prompt)}")
                 logging.info(f"  Messages count: {len(messages)}")
                 logging.info(f"  Temperature: {temperature}")
@@ -69,7 +69,7 @@ class ClaudeClient(LLMClient):
                 # Convert to sync call wrapped in async
                 response = await asyncio.to_thread(
                     self.client.messages.create,
-                    model="claude-3-5-sonnet-20241022",
+                    model="claude-opus-4-1-20250805",
                     system=system_prompt,
                     messages=messages,
                     temperature=temperature,


### PR DESCRIPTION
Updated the Claude model string in anthropic_client.py from claude-3-5-sonnet-20241022 to claude-opus-4-1-20250805.

This addresses issue #4 by updating the model parameter in both the logging message and the actual API call.

Generated with [Claude Code](https://claude.ai/code)