### PR TITLE
feat: upgrade GPT model to gpt-5-2025-08-07

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,6 @@ If you encounter API errors:
 
 ## Notes
 
-- GPT-5 is simulated using GPT-4 Turbo until GPT-5 is available
+- Uses GPT-5 (gpt-5-2025-08-07)
 - Gemini 2.0 Pro falls back to Gemini Pro if not available
 - Discussion time varies based on API response times (typically 5-10 minutes)

--- a/llm/openai_client.py
+++ b/llm/openai_client.py
@@ -39,7 +39,7 @@ class GPTClient(LLMClient):
                 # Convert to sync call wrapped in async
                 response = await asyncio.to_thread(
                     self.client.chat.completions.create,
-                    model="gpt-4-turbo-preview",  # Using GPT-4 as placeholder
+                    model="gpt-5-2025-08-07",
                     messages=messages_formatted,
                     temperature=temperature,
                     max_tokens=max_tokens


### PR DESCRIPTION
Upgrades the GPT model configuration from gpt-4-turbo-preview to gpt-5-2025-08-07 as requested in issue #6.

## Changes
- Updated model version in `llm/openai_client.py`
- Updated README.md documentation to reflect actual GPT-5 usage

Resolves #6

Generated with [Claude Code](https://claude.ai/code)