### PR TITLE
fix: standardize Gemini model references to Gemini 2.5 Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Python terminal application that orchestrates structured, truth-seeking discus
 
 ## Features
 - Structured 4-round Socratic discussions
-- Three AI panelists (GPT-5, Claude 4.1, Gemini Pro) with a Claude moderator
+- Three AI panelists (GPT-5, Claude 4.1, Gemini 2.5 Pro) with a Claude moderator
 - Automatic session saving and replay functionality
 - Clean terminal UI with rich formatting
 - Graceful error handling and interruption support
@@ -65,5 +65,5 @@ If you encounter API errors:
 ## Notes
 
 - Uses GPT-5 (gpt-5-2025-08-07)
-- Gemini 2.0 Pro falls back to Gemini Pro if not available
+- Gemini 2.5 Pro falls back to Gemini Pro if not available
 - Discussion time varies based on API response times (typically 5-10 minutes)

--- a/main.py
+++ b/main.py
@@ -40,7 +40,7 @@ class RoundtableApp:
             "claude_moderator": "Claude 4.1 Opus",
             "claude": "Claude 4.1 Opus",
             "gpt5": "GPT-5 Thinking",
-            "gemini": "Gemini 2.0 Pro"
+            "gemini": "Gemini 2.5 Pro"
         }
         
         self.current_session_file = None


### PR DESCRIPTION
Fixes ##8

This PR standardizes all Gemini model references across the repository to consistently use "Gemini 2.5 Pro" to match the actual model being used in `google_client.py` (`gemini-2.5-pro`).

## Changes
- Updated `main.py` participant model name from "Gemini 2.0 Pro" to "Gemini 2.5 Pro"
- Updated `README.md` feature description from "Gemini Pro" to "Gemini 2.5 Pro"
- Updated `README.md` notes section from "Gemini 2.0 Pro" to "Gemini 2.5 Pro"

Generated with [Claude Code](https://claude.ai/code)