### PR TITLE
Fix GPT-5 temperature parameter error

### DIFF
--- a/llm/openai_client.py
+++ b/llm/openai_client.py
@@ -38,11 +38,11 @@ class GPTClient(LLMClient):
                 
                 # Convert to sync call wrapped in async
                 # GPT-5 uses max_completion_tokens instead of max_tokens
+                # GPT-5 only supports default temperature (1), so we omit temperature parameter
                 response = await asyncio.to_thread(
                     self.client.chat.completions.create,
                     model="gpt-5-2025-08-07",
                     messages=messages_formatted,
-                    temperature=temperature,
                     max_completion_tokens=max_tokens
                 )
                 


### PR DESCRIPTION
Fixes #12

Remove temperature parameter from GPT-5 API calls as GPT-5 only supports the default temperature value of 1. This fixes the 400 error with unsupported_value code that was being thrown.

Generated with [Claude Code](https://claude.ai/code)