### PR TITLE
docs: remove Windows-related notes from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Python terminal application that orchestrates structured, truth-seeking discus
 1. Create a virtual environment:
 ```bash
 python3 -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
+source venv/bin/activate
 ```
 
 2. Install dependencies:


### PR DESCRIPTION
Fixes #17

Removed Windows-specific activation command comment from virtual environment setup instructions in README.md.

Generated with [Claude Code](https://claude.ai/code)