### PR TITLE
Remove unnecessary enter key requirement for session browsing

### DIFF
--- a/main.py
+++ b/main.py
@@ -246,8 +246,8 @@ class RoundtableApp:
                 break
             else:
                 # Not final synthesis - allow space to continue or F to fast forward
-                prompt = "\n[Press Space to continue, F to fast forward to final synthesis...]"
-                user_input = input(prompt).strip().lower()
+                self.ui.console.print("\n[Press Space to continue, F to fast forward to final synthesis...]")
+                user_input = self.ui.get_single_keypress()
                 
                 if user_input == 'f':
                     # Fast forward to final synthesis
@@ -274,6 +274,12 @@ class RoundtableApp:
                     
                     # If no convergence round found, show message and continue normally
                     self.ui.console.print("[yellow]No final synthesis found in this session.[/yellow]")
+                    continue
+                elif user_input == ' ':
+                    # Space key - continue to next message (this is the normal flow)
+                    continue
+                else:
+                    # Any other key - treat as space and continue
                     continue
         
         # Show final consensus if available (for cases where we didn't fast forward)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -18,6 +18,7 @@ def test_imports():
         from models.discussion import Role, Round, Message, DiscussionState
         from moderator.turn_manager import TurnManager
         from storage.session_logger import SessionLogger
+        from ui.terminal import TerminalUI
         assert True
     except ImportError as e:
         pytest.fail(f"Import failed: {e}")

--- a/ui/terminal.py
+++ b/ui/terminal.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import termios
+import tty
 from typing import Optional
 from rich.console import Console
 from rich.panel import Panel
@@ -120,3 +122,18 @@ class TerminalUI:
             padding=(1, 2)
         )
         self.console.print(panel)
+    
+    def get_single_keypress(self) -> str:
+        """Get a single keypress without requiring Enter"""
+        if os.name == 'nt':  # Windows
+            import msvcrt
+            return msvcrt.getch().decode('utf-8').lower()
+        else:  # Unix/Linux/macOS
+            fd = sys.stdin.fileno()
+            old_settings = termios.tcgetattr(fd)
+            try:
+                tty.setraw(sys.stdin.fileno())
+                ch = sys.stdin.read(1).lower()
+                return ch
+            finally:
+                termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)


### PR DESCRIPTION
Fixes #26

This PR removes the unnecessary enter key requirement when browsing saved sessions, improving the user experience:

- **Space key**: Now directly continues to next page (no enter needed)
- **F key**: Now directly fast forwards to final synthesis (no enter needed)
- **Enter key**: Still required only to return to main menu from final synthesis page

## Technical Details
- Added cross-platform single keypress capture functionality to TerminalUI
- Modified session replay navigation logic to use single keypress
- Updated tests to ensure compatibility

Generated with [Claude Code](https://claude.ai/code)