### PR TITLE
Fix issue #30: Update README with hotkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ python main.py
 
 - Sessions are automatically saved to the `sessions/` directory when discussions complete
 - Load and replay previous discussions from the main menu
+- **Session Replay Hotkeys:**
+  - **Space**: Continue to next message (single keypress)
+  - **F**: Fast forward to final synthesis (single keypress)
+  - **Enter**: Return to main menu (from final synthesis page)
 - Ctrl+C exits the application
 
 ## Requirements


### PR DESCRIPTION
This pull request fixes #30.

The issue has been successfully resolved. The task was to update the "Session Management" section of the README to reflect the hotkeys that were added in PR #27. The AI agent made the appropriate changes by adding a new subsection called "Session Replay Hotkeys" within the Session Management section that documents three hotkeys:

1. **Space**: Continue to next message (single keypress)
2. **F**: Fast forward to final synthesis (single keypress) 
3. **Enter**: Return to main menu (from final synthesis page)

This addition directly addresses the issue requirement by updating the README documentation to reflect the hotkey functionality that was previously added to the codebase. The formatting is consistent with the existing README structure, using bullet points and bold text for emphasis. The changes are placed logically within the Session Management section where users would expect to find information about session replay controls.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌