### PR TITLE
Fix issue #53: Add a new speaker to the panel

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,7 +40,8 @@ class RoundtableApp:
             "claude_moderator": "Claude 4.1 Opus",
             "claude": "Claude 4.1 Opus",
             "gpt5": "GPT-5 Thinking",
-            "gemini": "Gemini 2.5 Pro"
+            "gemini": "Gemini 2.5 Pro",
+            "deepseek-llama": "Lambda Deepseek LLaMA 3.3 70B"
         }
         
         self.current_session_file = None

--- a/moderator/turn_manager.py
+++ b/moderator/turn_manager.py
@@ -4,7 +4,7 @@ import random
 
 class TurnManager:
     def __init__(self):
-        self.panelist_ids = ["gpt5", "claude", "gemini"]
+        self.panelist_ids = ["gpt5", "claude", "gemini", "deepseek-llama"]
         self.moderator_id = "claude_moderator"
     
     def determine_next_speaker(self, state: DiscussionState) -> str:


### PR DESCRIPTION
This pull request fixes #53.

The changes made in the PR successfully add the "deepseek-llama3.3-70b" speaker to the panel discussion. The addition of "deepseek-llama" to both the panelist_ids in turn_manager.py and the participant_models in main.py ensures that the new speaker is recognized and integrated into the system. These changes effectively address the issue by enabling the new model's participation in the panel.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌