### PR TITLE
Fix UI prompt visibility during discussion runtime

### DIFF
--- a/web/server.py
+++ b/web/server.py
@@ -196,6 +196,12 @@ class WebRoundtableSession:
             completed_at=None
         )
         
+        # Hide the prompt during discussion - no user input should be allowed
+        await self.ws_manager.broadcast({
+            'type': 'prompt',
+            'prompt': ''
+        })
+        
         turn_number = 0
         retry_count = 0
         max_retries = 3
@@ -231,6 +237,11 @@ class WebRoundtableSession:
                 
                 if retry_count >= max_retries:
                     await self.ui.send_error("Max retries exceeded. Exiting.")
+                    # Restore prompt on error
+                    await self.ws_manager.broadcast({
+                        'type': 'prompt',
+                        'prompt': '$ '
+                    })
                     return
                 
                 await self.ui.send_output("Retrying in 3 seconds...")
@@ -274,7 +285,7 @@ class WebRoundtableSession:
                     self.ws_manager.current_session = None
                     
                     # Reset prompt to default
-                    await ws_manager.send_to_client(websocket, {
+                    await self.ws_manager.broadcast({
                         'type': 'prompt',
                         'prompt': '$ '
                     })


### PR DESCRIPTION
Fixes #60

This PR addresses the UI issue where the "Topic" prompt with blinking cursor appeared during discussion runtime, allowing users to type when they should wait for the discussion to complete.

## Changes
- Hide the "Topic" prompt when discussion starts by setting empty prompt
- Restore normal "$ " prompt when discussion completes or encounters errors
- Fix existing bug in prompt restoration code that used incorrect variables

## Testing
The fix ensures:
1. During discussion runtime: No prompt is visible, no cursor blinking, no user input allowed
2. After discussion completion: "Press enter to return to main menu" message appears
3. Error handling: Prompt is restored even if discussion fails

Generated with [Claude Code](https://claude.ai/code)