### PR TITLE
Implement session isolation for websocket connections

### DIFF
--- a/web/web_ui.py
+++ b/web/web_ui.py
@@ -7,8 +7,9 @@ if TYPE_CHECKING:
 class WebUI:
     """Web-based UI that mirrors the terminal UI functionality"""
     
-    def __init__(self, websocket_manager: 'WebSocketManager'):
+    def __init__(self, websocket_manager: 'WebSocketManager', websocket=None):
         self.ws_manager = websocket_manager
+        self.websocket = websocket  # Specific websocket for this UI instance
         self.round_names = {
             Round.AGENDA: "Agenda Framing",
             Round.EVIDENCE: "Evidence Presentation",
@@ -25,27 +26,44 @@ class WebUI:
     
     async def clear_screen(self):
         """Clear the web terminal screen"""
-        await self.ws_manager.broadcast({
-            'type': 'clear'
-        })
+        if self.websocket:
+            await self.ws_manager.broadcast_to_client(self.websocket, {
+                'type': 'clear'
+            })
+        else:
+            # Fallback to broadcast if no specific websocket (backward compatibility)
+            for client in self.ws_manager.clients:
+                await self.ws_manager.send_to_client(client, {
+                    'type': 'clear'
+                })
     
     async def display_header(self, topic: str, current_round: Round):
         """Display discussion header"""
-        await self.ws_manager.broadcast({
+        message = {
             'type': 'header',
             'topic': topic,
             'round': self.round_names[current_round]
-        })
+        }
+        if self.websocket:
+            await self.ws_manager.broadcast_to_client(self.websocket, message)
+        else:
+            for client in self.ws_manager.clients:
+                await self.ws_manager.send_to_client(client, message)
     
     async def display_message(self, message: Message):
         """Display a single message"""
-        await self.ws_manager.broadcast({
+        msg = {
             'type': 'message',
             'participant_id': message.participant_id,
             'participant_model': message.participant_model,
             'content': message.content,
             'is_moderator': message.role == Role.MODERATOR
-        })
+        }
+        if self.websocket:
+            await self.ws_manager.broadcast_to_client(self.websocket, msg)
+        else:
+            for client in self.ws_manager.clients:
+                await self.ws_manager.send_to_client(client, msg)
     
     async def display_thinking(self, participant: str):
         """Show thinking indicator"""
@@ -56,38 +74,63 @@ class WebUI:
             "gemini": "Gemini"
         }
         
-        await self.ws_manager.broadcast({
+        msg = {
             'type': 'thinking',
             'participant': participant_names.get(participant, participant)
-        })
+        }
+        if self.websocket:
+            await self.ws_manager.broadcast_to_client(self.websocket, msg)
+        else:
+            for client in self.ws_manager.clients:
+                await self.ws_manager.send_to_client(client, msg)
     
     async def display_round_transition(self, from_round: Round, to_round: Round):
         """Display round transition"""
-        await self.ws_manager.broadcast({
+        msg = {
             'type': 'round_transition',
             'from_round': self.round_names[from_round],
             'to_round': self.round_names[to_round]
-        })
+        }
+        if self.websocket:
+            await self.ws_manager.broadcast_to_client(self.websocket, msg)
+        else:
+            for client in self.ws_manager.clients:
+                await self.ws_manager.send_to_client(client, msg)
     
     async def display_final_consensus(self, consensus: str):
         """Display final consensus"""
-        await self.ws_manager.broadcast({
+        msg = {
             'type': 'final_consensus',
             'content': consensus
-        })
+        }
+        if self.websocket:
+            await self.ws_manager.broadcast_to_client(self.websocket, msg)
+        else:
+            for client in self.ws_manager.clients:
+                await self.ws_manager.send_to_client(client, msg)
     
     async def send_output(self, content: str, style: str = ''):
         """Send general output message"""
-        await self.ws_manager.broadcast({
+        msg = {
             'type': 'output',
             'content': content,
             'style': style
-        })
+        }
+        if self.websocket:
+            await self.ws_manager.broadcast_to_client(self.websocket, msg)
+        else:
+            for client in self.ws_manager.clients:
+                await self.ws_manager.send_to_client(client, msg)
     
     async def send_error(self, content: str):
         """Send error message"""
-        await self.ws_manager.broadcast({
+        msg = {
             'type': 'output',
             'content': content,
             'style': 'error-message'
-        })
+        }
+        if self.websocket:
+            await self.ws_manager.broadcast_to_client(self.websocket, msg)
+        else:
+            for client in self.ws_manager.clients:
+                await self.ws_manager.send_to_client(client, msg)


### PR DESCRIPTION
Implements session isolation so that each websocket connection has its own state instead of sharing state across all connections.

**Changes:**
- Replace shared current_session with per-client client_sessions dict
- Store individual WebRoundtableSession instances per websocket connection
- Update WebUI to send messages to specific clients instead of broadcasting
- Add proper cleanup of client sessions and states on disconnect
- Ensure each connection has isolated discussion state

Fixes #62

🤖 Generated with [Claude Code](https://claude.ai/code)